### PR TITLE
Resolve constructor arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,9 @@ class UsersControllerTest {
 -   private UsersController usersController;
 +   private UsersService usersService = Mockito.mock(UsersService.class);
 +   private UsernameService usernameService = Mockito.mock(UsernameService.class);
-+   private UsersController usersController = new UsersController();
++   private UsersController usersController = new UsersController(usersService, usernameService);
 }
 ```
-
-**Note:** The constructor arguments above, `userService` and `usernameService`, are not passed to `UsersController`. 
-This can easily be done manually, of course it is better if it is automated.
 
 ## Usage
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,13 +65,14 @@
         <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
         <dokka-maven-plugin.version>0.10.0</dokka-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+        <mockk.version>1.9.3</mockk.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>com.github.javaparser</groupId>
-                <artifactId>javaparser-core</artifactId>
+                <artifactId>javaparser-symbol-solver-core</artifactId>
                 <version>${java-parser.version}</version>
             </dependency>
             <dependency>
@@ -116,6 +117,12 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj-core.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.mockk</groupId>
+                <artifactId>mockk</artifactId>
+                <version>${mockk.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/reboot-core/pom.xml
+++ b/reboot-core/pom.xml
@@ -16,7 +16,7 @@
     <dependencies>
         <dependency>
             <groupId>com.github.javaparser</groupId>
-            <artifactId>javaparser-core</artifactId>
+            <artifactId>javaparser-symbol-solver-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
@@ -44,6 +44,10 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk</artifactId>
         </dependency>
     </dependencies>
 

--- a/reboot-core/src/main/kotlin/nl/thanus/reboot/refactoring/Autowired.kt
+++ b/reboot-core/src/main/kotlin/nl/thanus/reboot/refactoring/Autowired.kt
@@ -50,10 +50,10 @@ private fun isTest(compilationUnit: CompilationUnit) =
 private fun isLombokConstructorAnnotation(annotationExpr: AnnotationExpr) =
         annotationExpr.name == Name("RequiredArgsConstructor") || annotationExpr.name == Name("AllArgsConstructor")
 
-private fun containsAutowiredAnnotation(fieldDeclaration: FieldDeclaration) =
+fun containsAutowiredAnnotation(fieldDeclaration: FieldDeclaration) =
         fieldDeclaration.annotations.any { isAutowiredAnnotation(it) }
 
-private fun isAutowiredAnnotation(annotationExpr: AnnotationExpr) = annotationExpr.name == Name("Autowired")
+fun isAutowiredAnnotation(annotationExpr: AnnotationExpr) = annotationExpr.name == Name("Autowired")
 
 private fun removeAutowiredOnFieldAndMakeFinal(fieldDeclaration: FieldDeclaration) {
     fieldDeclaration.tryRemoveImportFromCompilationUnit("org.springframework.beans.factory.annotation.Autowired")

--- a/reboot-core/src/main/kotlin/nl/thanus/reboot/refactoring/Mockito.kt
+++ b/reboot-core/src/main/kotlin/nl/thanus/reboot/refactoring/Mockito.kt
@@ -2,6 +2,7 @@ package nl.thanus.reboot.refactoring
 
 import com.github.javaparser.ast.CompilationUnit
 import com.github.javaparser.ast.ImportDeclaration
+import com.github.javaparser.ast.Modifier
 import com.github.javaparser.ast.NodeList
 import com.github.javaparser.ast.body.FieldDeclaration
 import com.github.javaparser.ast.body.VariableDeclarator
@@ -11,13 +12,21 @@ import com.github.javaparser.ast.expr.Expression
 import com.github.javaparser.ast.expr.MethodCallExpr
 import com.github.javaparser.ast.expr.Name
 import com.github.javaparser.ast.expr.NameExpr
+import com.github.javaparser.ast.expr.NullLiteralExpr
 import com.github.javaparser.ast.expr.ObjectCreationExpr
 import com.github.javaparser.ast.type.ClassOrInterfaceType
+import com.github.javaparser.ast.type.Type
+import com.github.javaparser.resolution.UnsolvedSymbolException
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserClassDeclaration
+import mu.KotlinLogging
+import java.nio.file.Path
 
 private const val MOCK = "Mock"
 private const val SPY = "Spy"
 private const val INJECT_MOCKS = "InjectMocks"
 private const val MOCKITO = "Mockito"
+
+private val logger = KotlinLogging.logger { }
 
 fun rewriteMockitoFieldInjections(compilationUnit: CompilationUnit) {
     compilationUnit.findAll(FieldDeclaration::class.java)
@@ -84,6 +93,7 @@ private fun rewriteAnnotation(fieldDeclaration: FieldDeclaration, mockitoAnnotat
 
 private fun instantiateObject(fieldDeclaration: FieldDeclaration): NodeList<VariableDeclarator> {
     val variableDeclarator = fieldDeclaration.variables.first()
+    val constructorArguments = resolveAndMatchConstructorArguments(variableDeclarator, fieldDeclaration)
 
     return NodeList(
             VariableDeclarator(
@@ -92,10 +102,90 @@ private fun instantiateObject(fieldDeclaration: FieldDeclaration): NodeList<Vari
                     ObjectCreationExpr(
                             null,
                             variableDeclarator.type as ClassOrInterfaceType,
-                            NodeList()
+                            NodeList(constructorArguments)
                     )
             )
     )
+}
+
+private fun resolveAndMatchConstructorArguments(variableDeclarator: VariableDeclarator, fieldDeclaration: FieldDeclaration): List<Expression> {
+    val arguments = mutableListOf<Expression>()
+
+    try {
+        val fieldDeclarationsInTest = fieldDeclaration.findAncestor(CompilationUnit::class.java)
+                .map { it.findAll(FieldDeclaration::class.java) }
+                .orElse(emptyList())
+
+        resolveConstructorArguments(variableDeclarator).forEach { type ->
+            if (fieldDeclarationsInTest.any { it.elementType == type }) {
+                val matchedField = fieldDeclarationsInTest.first { it.elementType == type }
+                val variableName = matchedField.variables.first().name
+                arguments.add(NameExpr(variableName))
+            } else {
+                logger.warn { "No matching $type argument found. Adding NullLiteralExpr as constructor argument." }
+                arguments.add(NullLiteralExpr())
+            }
+        }
+    } catch (e: UnsolvedSymbolException) {
+        val path: Path? = variableDeclarator.findAncestor(CompilationUnit::class.java)
+                .flatMap { it.storage }
+                .map { it.path }
+                .orElse(null)
+
+        logger.warn(e) { "Symbol ${e.name} cannot be resolved. Object creation will not have any constructor arguments. Location: $path" }
+    }
+
+    return arguments
+}
+
+private fun resolveConstructorArguments(variableDeclarator: VariableDeclarator): List<Type> {
+    val typeDeclaration = variableDeclarator.type.resolve().asReferenceType().typeDeclaration
+
+    if (typeDeclaration !is JavaParserClassDeclaration) {
+        return emptyList()
+    }
+
+    val classOrInterface = typeDeclaration.wrappedNode
+    val fields = classOrInterface.findAll(FieldDeclaration::class.java)
+
+    if (fields.any { containsAutowiredAnnotation(it) }) {
+        return fields.filter { containsAutowiredAnnotation(it) }.map { it.elementType }
+    }
+
+    if (classOrInterface.annotations.any { isAnnotation(it, Name("RequiredArgsConstructor")) }) {
+        return fields.filter { isFinalField(it) }.map { it.elementType }
+    }
+
+    if (classOrInterface.annotations.any { isAnnotation(it, Name("AllArgsConstructor")) }) {
+        return fields.filter { isNonStaticInitializedField(it) }.map { it.elementType }
+    }
+
+    val constructors = classOrInterface.constructors
+    if (constructors.isNotEmpty()) {
+        if (constructors.size == 1) {
+            return constructors.first().parameters.map { it.type }
+        }
+
+        val parametersType = constructors.firstOrNull { constructor ->
+            constructor.annotations.any { isAutowiredAnnotation(it) }
+        }?.parameters?.map { it.type }
+
+        return parametersType ?: emptyList()
+    }
+
+    return emptyList()
+}
+
+fun isFinalField(fieldDeclaration: FieldDeclaration): Boolean {
+    val isFinalFields = fieldDeclaration.modifiers.any { it.keyword == Modifier.Keyword.FINAL }
+    return isFinalFields && isNonStaticInitializedField(fieldDeclaration)
+}
+
+fun isNonStaticInitializedField(fieldDeclaration: FieldDeclaration): Boolean {
+    val isNoStaticFields = !fieldDeclaration.modifiers.any { it.keyword == Modifier.Keyword.STATIC }
+    val isNoVariableInitializer = !fieldDeclaration.variables.any { it.initializer.isPresent }
+
+    return isNoStaticFields && isNoVariableInitializer
 }
 
 private fun addMockitoImportToCompilationUnit(fieldDeclaration: FieldDeclaration) =

--- a/reboot-core/src/main/kotlin/nl/thanus/reboot/refactoring/RequestMapping.kt
+++ b/reboot-core/src/main/kotlin/nl/thanus/reboot/refactoring/RequestMapping.kt
@@ -14,7 +14,7 @@ import com.github.javaparser.ast.expr.SimpleName
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr
 import mu.KotlinLogging
 
-val logger = KotlinLogging.logger { }
+private val logger = KotlinLogging.logger { }
 
 fun rewriteRequestMappings(compilationUnit: CompilationUnit) {
     compilationUnit.findAll(MethodDeclaration::class.java)

--- a/reboot-core/src/test/kotlin/nl/thanus/reboot/refactoring/MockitoKtTest.kt
+++ b/reboot-core/src/test/kotlin/nl/thanus/reboot/refactoring/MockitoKtTest.kt
@@ -1,6 +1,16 @@
 package nl.thanus.reboot.refactoring
 
 import com.github.javaparser.StaticJavaParser
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration
+import com.github.javaparser.symbolsolver.JavaSymbolSolver
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserClassDeclaration
+import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserInterfaceDeclaration
+import com.github.javaparser.symbolsolver.resolution.typesolvers.MemoryTypeSolver
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 internal class MockitoKtTest : ReBootBase() {
@@ -55,27 +65,531 @@ internal class MockitoKtTest : ReBootBase() {
         assertRefactored(compilationUnit, expectedCode)
     }
 
-    @Test
-    fun `Rewrite @InjectMocks with object creation`() {
-        val code = """
-            import org.mockito.InjectMocks;
-            
-            class UsersControllerTest {
-                @InjectMocks
-                private UsersController usersController;
+    @Nested
+    @DisplayName("Rewrite @InjectMocks with object creation")
+    inner class InjectMocks {
+
+        @Nested
+        @DisplayName("When resolved class has autowired fields")
+        inner class AutowiredFields {
+
+            @Test
+            fun `Resolve constructor arguments`() {
+                val typeDeclaration = mockk<JavaParserClassDeclaration>()
+                configureTypeSolver(typeDeclaration)
+
+                val compilationUnit = StaticJavaParser.parse(classWithInjectMocks())
+
+                val clazz = """
+                    public class UsersController {
+                        @Autowired
+                        private UsersService usersService;
+                        @Autowired
+                        private UsernameService usernameService;
+                    }
+                """.trimIndent()
+
+                val classOrInterfaceDeclaration = StaticJavaParser.parseTypeDeclaration(clazz) as ClassOrInterfaceDeclaration
+
+                every { typeDeclaration.isTypeParameter } returns false
+                every { typeDeclaration.wrappedNode } returns classOrInterfaceDeclaration
+
+                rewriteMockitoFieldInjections(compilationUnit)
+
+                val expectedCode = """
+                    import nl.thanus.demo.controllers.UsersController;
+                    import org.mockito.Mockito;
+                    
+                    class UsersControllerTest {
+                        private UsersService usersService = Mockito.mock(UsersService.class);
+                        private UsernameService usernameService = Mockito.mock(UsernameService.class);
+                        private UsersController usersController = new UsersController(usersService, usernameService);
+                    }
+                """.trimIndent()
+
+                assertRefactored(compilationUnit, expectedCode)
             }
-        """.trimIndent()
-        val compilationUnit = StaticJavaParser.parse(code)
 
-        rewriteMockitoFieldInjections(compilationUnit)
+            @Test
+            fun `Resolve constructor arguments only containing autowired`() {
+                val typeDeclaration = mockk<JavaParserClassDeclaration>()
+                configureTypeSolver(typeDeclaration)
 
-        val expectedCode = """
-            class UsersControllerTest {
-                private UsersController usersController = new UsersController();
+                val compilationUnit = StaticJavaParser.parse(classWithInjectMocks())
+
+                val clazz = """
+                    public class UsersController {
+                        @Autowired
+                        private UsersService usersService;
+                        @Autowired
+                        private UsernameService usernameService;
+                        private Object object;
+                    }
+                """.trimIndent()
+
+                val classOrInterfaceDeclaration = StaticJavaParser.parseTypeDeclaration(clazz) as ClassOrInterfaceDeclaration
+
+                every { typeDeclaration.isTypeParameter } returns false
+                every { typeDeclaration.wrappedNode } returns classOrInterfaceDeclaration
+
+                rewriteMockitoFieldInjections(compilationUnit)
+
+                val expectedCode = """
+                    import nl.thanus.demo.controllers.UsersController;
+                    import org.mockito.Mockito;
+                    
+                    class UsersControllerTest {
+                        private UsersService usersService = Mockito.mock(UsersService.class);
+                        private UsernameService usernameService = Mockito.mock(UsernameService.class);
+                        private UsersController usersController = new UsersController(usersService, usernameService);
+                    }
+                """.trimIndent()
+
+                assertRefactored(compilationUnit, expectedCode)
             }
-        """.trimIndent()
+        }
 
-        assertRefactored(compilationUnit, expectedCode)
+        @Nested
+        @DisplayName("When resolved class has RequiredArgsConstructor")
+        inner class RequiredArgsConstructor {
+
+            @Test
+            fun `Resolve constructor arguments`() {
+                val typeDeclaration = mockk<JavaParserClassDeclaration>()
+                configureTypeSolver(typeDeclaration)
+
+                val compilationUnit = StaticJavaParser.parse(classWithInjectMocks())
+
+                val clazz = """
+                    @RequiredArgsConstructor
+                    public class UsersController {
+                        private final UsersService usersService;
+                        private final UsernameService usernameService;
+                    }
+                """.trimIndent()
+
+                val classOrInterfaceDeclaration = StaticJavaParser.parseTypeDeclaration(clazz) as ClassOrInterfaceDeclaration
+
+                every { typeDeclaration.isTypeParameter } returns false
+                every { typeDeclaration.wrappedNode } returns classOrInterfaceDeclaration
+
+                rewriteMockitoFieldInjections(compilationUnit)
+
+                val expectedCode = """
+                    import nl.thanus.demo.controllers.UsersController;
+                    import org.mockito.Mockito;
+                    
+                    class UsersControllerTest {
+                        private UsersService usersService = Mockito.mock(UsersService.class);
+                        private UsernameService usernameService = Mockito.mock(UsernameService.class);
+                        private UsersController usersController = new UsersController(usersService, usernameService);
+                    }
+                """.trimIndent()
+
+                assertRefactored(compilationUnit, expectedCode)
+            }
+
+            @Test
+            fun `Resolve constructor arguments without a non-required field`() {
+                val typeDeclaration = mockk<JavaParserClassDeclaration>()
+                configureTypeSolver(typeDeclaration)
+
+                val compilationUnit = StaticJavaParser.parse(classWithInjectMocks())
+
+                val clazz = """
+                    @RequiredArgsConstructor
+                    public class UsersController {
+                        private final UsersService usersService;
+                        private final UsernameService usernameService;
+                        private Object object;
+                    }
+                """.trimIndent()
+
+                val classOrInterfaceDeclaration = StaticJavaParser.parseTypeDeclaration(clazz) as ClassOrInterfaceDeclaration
+
+                every { typeDeclaration.isTypeParameter } returns false
+                every { typeDeclaration.wrappedNode } returns classOrInterfaceDeclaration
+
+                rewriteMockitoFieldInjections(compilationUnit)
+
+                val expectedCode = """
+                    import nl.thanus.demo.controllers.UsersController;
+                    import org.mockito.Mockito;
+                    
+                    class UsersControllerTest {
+                        private UsersService usersService = Mockito.mock(UsersService.class);
+                        private UsernameService usernameService = Mockito.mock(UsernameService.class);
+                        private UsersController usersController = new UsersController(usersService, usernameService);
+                    }
+                """.trimIndent()
+
+                assertRefactored(compilationUnit, expectedCode)
+            }
+        }
+
+        @Nested
+        @DisplayName("When resolved class has AllArgsConstructor")
+        inner class AllArgsConstructor {
+
+            @Test
+            fun `Resolve constructor arguments`() {
+                val typeDeclaration = mockk<JavaParserClassDeclaration>()
+                configureTypeSolver(typeDeclaration)
+
+                val compilationUnit = StaticJavaParser.parse(classWithInjectMocks())
+
+                val clazz = """
+                    @AllArgsConstructor
+                    public class UsersController {
+                        private final UsersService usersService;
+                        private final UsernameService usernameService;
+                    }
+                """.trimIndent()
+
+                val classOrInterfaceDeclaration = StaticJavaParser.parseTypeDeclaration(clazz) as ClassOrInterfaceDeclaration
+
+                every { typeDeclaration.isTypeParameter } returns false
+                every { typeDeclaration.wrappedNode } returns classOrInterfaceDeclaration
+
+                rewriteMockitoFieldInjections(compilationUnit)
+
+                val expectedCode = """
+                    import nl.thanus.demo.controllers.UsersController;
+                    import org.mockito.Mockito;
+                    
+                    class UsersControllerTest {
+                        private UsersService usersService = Mockito.mock(UsersService.class);
+                        private UsernameService usernameService = Mockito.mock(UsernameService.class);
+                        private UsersController usersController = new UsersController(usersService, usernameService);
+                    }
+                """.trimIndent()
+
+                assertRefactored(compilationUnit, expectedCode)
+            }
+
+            @Test
+            fun `Resolve constructor arguments when fields are not final`() {
+                val typeDeclaration = mockk<JavaParserClassDeclaration>()
+                configureTypeSolver(typeDeclaration)
+
+                val compilationUnit = StaticJavaParser.parse(classWithInjectMocks())
+
+                val clazz = """
+                    @AllArgsConstructor
+                    public class UsersController {
+                        private UsersService usersService;
+                        private UsernameService usernameService;
+                    }
+                """.trimIndent()
+
+                val classOrInterfaceDeclaration = StaticJavaParser.parseTypeDeclaration(clazz) as ClassOrInterfaceDeclaration
+
+                every { typeDeclaration.isTypeParameter } returns false
+                every { typeDeclaration.wrappedNode } returns classOrInterfaceDeclaration
+
+                rewriteMockitoFieldInjections(compilationUnit)
+
+                val expectedCode = """
+                    import nl.thanus.demo.controllers.UsersController;
+                    import org.mockito.Mockito;
+                    
+                    class UsersControllerTest {
+                        private UsersService usersService = Mockito.mock(UsersService.class);
+                        private UsernameService usernameService = Mockito.mock(UsernameService.class);
+                        private UsersController usersController = new UsersController(usersService, usernameService);
+                    }
+                """.trimIndent()
+
+                assertRefactored(compilationUnit, expectedCode)
+            }
+
+            @Test
+            fun `Resolve constructor arguments without a static initialized field`() {
+                val typeDeclaration = mockk<JavaParserClassDeclaration>()
+                configureTypeSolver(typeDeclaration)
+
+                val compilationUnit = StaticJavaParser.parse(classWithInjectMocks())
+
+                val clazz = """
+                    @AllArgsConstructor
+                    public class UsersController {
+                        private final UsersService usersService;
+                        private final UsernameService usernameService;
+                        public static int COUNTER = 1;
+                    }
+                """.trimIndent()
+
+                val classOrInterfaceDeclaration = StaticJavaParser.parseTypeDeclaration(clazz) as ClassOrInterfaceDeclaration
+
+                every { typeDeclaration.isTypeParameter } returns false
+                every { typeDeclaration.wrappedNode } returns classOrInterfaceDeclaration
+
+                rewriteMockitoFieldInjections(compilationUnit)
+
+                val expectedCode = """
+                    import nl.thanus.demo.controllers.UsersController;
+                    import org.mockito.Mockito;
+                    
+                    class UsersControllerTest {
+                        private UsersService usersService = Mockito.mock(UsersService.class);
+                        private UsernameService usernameService = Mockito.mock(UsernameService.class);
+                        private UsersController usersController = new UsersController(usersService, usernameService);
+                    }
+                """.trimIndent()
+
+                assertRefactored(compilationUnit, expectedCode)
+            }
+        }
+
+        @Nested
+        @DisplayName("When resolved class has a constructor")
+        inner class Constructor {
+
+            @Test
+            fun `Resolve constructor arguments when single constructor`() {
+                val typeDeclaration = mockk<JavaParserClassDeclaration>()
+                configureTypeSolver(typeDeclaration)
+
+                val compilationUnit = StaticJavaParser.parse(classWithInjectMocks())
+
+                val clazz = """
+                    public class UsersController {
+                        private final UsersService usersService;
+                        private final UsernameService usernameService;
+
+                        public UsersController(UsersService usersService, UsernameService usernameService) {
+                            this.usersService = usersService;
+                            this.usernameService = usernameService;
+                        }
+                    }
+                """.trimIndent()
+
+                val classOrInterfaceDeclaration = StaticJavaParser.parseTypeDeclaration(clazz) as ClassOrInterfaceDeclaration
+
+                every { typeDeclaration.isTypeParameter } returns false
+                every { typeDeclaration.wrappedNode } returns classOrInterfaceDeclaration
+
+                rewriteMockitoFieldInjections(compilationUnit)
+
+                val expectedCode = """
+                    import nl.thanus.demo.controllers.UsersController;
+                    import org.mockito.Mockito;
+                    
+                    class UsersControllerTest {
+                        private UsersService usersService = Mockito.mock(UsersService.class);
+                        private UsernameService usernameService = Mockito.mock(UsernameService.class);
+                        private UsersController usersController = new UsersController(usersService, usernameService);
+                    }
+                """.trimIndent()
+
+                assertRefactored(compilationUnit, expectedCode)
+            }
+
+            @Test
+            fun `Resolve constructor arguments when multiple constructors (single autowired)`() {
+                val typeDeclaration = mockk<JavaParserClassDeclaration>()
+                configureTypeSolver(typeDeclaration)
+
+                val compilationUnit = StaticJavaParser.parse(classWithInjectMocks())
+
+                val clazz = """
+                    public class UsersController {
+                        private final UsersService usersService;
+                        private final UsernameService usernameService;
+
+                        @Autowired
+                        public UsersController(UsersService usersService, UsernameService usernameService) {
+                            this.usersService = usersService;
+                            this.usernameService = usernameService;
+                        }
+
+                        public UsersController() {
+                            this.usersService = null;
+                            this.usernameService = null;
+                        }
+                    }
+                """.trimIndent()
+
+                val classOrInterfaceDeclaration = StaticJavaParser.parseTypeDeclaration(clazz) as ClassOrInterfaceDeclaration
+
+                every { typeDeclaration.isTypeParameter } returns false
+                every { typeDeclaration.wrappedNode } returns classOrInterfaceDeclaration
+
+                rewriteMockitoFieldInjections(compilationUnit)
+
+                val expectedCode = """
+                    import nl.thanus.demo.controllers.UsersController;
+                    import org.mockito.Mockito;
+                    
+                    class UsersControllerTest {
+                        private UsersService usersService = Mockito.mock(UsersService.class);
+                        private UsernameService usernameService = Mockito.mock(UsernameService.class);
+                        private UsersController usersController = new UsersController(usersService, usernameService);
+                    }
+                """.trimIndent()
+
+                assertRefactored(compilationUnit, expectedCode)
+            }
+        }
+
+        @Test
+        fun `Object creation should not contain any constructor arguments when resolving type is not a class`() {
+            val typeDeclaration = mockk<JavaParserInterfaceDeclaration>()
+            configureTypeSolver(typeDeclaration)
+
+            val compilationUnit = StaticJavaParser.parse(classWithInjectMocks())
+
+            every { typeDeclaration.isTypeParameter } returns false
+
+            rewriteMockitoFieldInjections(compilationUnit)
+
+            val expectedCode = """
+                import nl.thanus.demo.controllers.UsersController;
+                import org.mockito.Mockito;
+                
+                class UsersControllerTest {
+                    private UsersService usersService = Mockito.mock(UsersService.class);
+                    private UsernameService usernameService = Mockito.mock(UsernameService.class);
+                    private UsersController usersController = new UsersController();
+                }
+            """.trimIndent()
+
+            assertRefactored(compilationUnit, expectedCode)
+        }
+
+        private fun classWithInjectMocks() = """
+                        import org.mockito.InjectMocks;
+                        import nl.thanus.demo.controllers.UsersController;
+                        
+                        class UsersControllerTest {
+                            @Mock
+                            private UsersService usersService;
+                            @Mock
+                            private UsernameService usernameService;
+                            @InjectMocks
+                            private UsersController usersController;
+                        }
+                    """.trimIndent()
+
+        @Test
+        fun `Use NullExpression as constructor argument when it cannot find matching field`() {
+            val code = """
+                import org.mockito.InjectMocks;
+                import nl.thanus.demo.controllers.UsersController;
+                
+                class UsersControllerTest {
+                    @Mock
+                    private UsersService usersService;
+                    @InjectMocks
+                    private UsersController usersController;
+                }
+            """.trimIndent()
+
+            val typeDeclaration = mockk<JavaParserClassDeclaration>()
+            configureTypeSolver(typeDeclaration)
+
+            val compilationUnit = StaticJavaParser.parse(code)
+
+            val clazz = """
+                @RequiredArgsConstructor
+                public class UsersController {
+                    private final UsersService usersService;
+                    private final UsernameService usernameService;
+                }
+            """.trimIndent()
+
+            val classOrInterfaceDeclaration = StaticJavaParser.parseTypeDeclaration(clazz) as ClassOrInterfaceDeclaration
+
+            every { typeDeclaration.isTypeParameter } returns false
+            every { typeDeclaration.wrappedNode } returns classOrInterfaceDeclaration
+
+            rewriteMockitoFieldInjections(compilationUnit)
+
+            val expectedCode = """
+                import nl.thanus.demo.controllers.UsersController;
+                import org.mockito.Mockito;
+                
+                class UsersControllerTest {
+                    private UsersService usersService = Mockito.mock(UsersService.class);
+                    private UsersController usersController = new UsersController(usersService, null);
+                }
+            """.trimIndent()
+
+            assertRefactored(compilationUnit, expectedCode)
+        }
+
+        @Test
+        fun `Object creation should not contain any argument when resolving class has no fields`() {
+            val code = """
+                import org.mockito.InjectMocks;
+                import nl.thanus.demo.controllers.UsersController;
+                
+                class UsersControllerTest {
+                    @InjectMocks
+                    private UsersController usersController;
+                }
+            """.trimIndent()
+
+            val typeDeclaration = mockk<JavaParserClassDeclaration>()
+            configureTypeSolver(typeDeclaration)
+
+            val compilationUnit = StaticJavaParser.parse(code)
+
+            val clazz = """
+                public class UsersController {
+                }
+            """.trimIndent()
+
+            val classOrInterfaceDeclaration = StaticJavaParser.parseTypeDeclaration(clazz) as ClassOrInterfaceDeclaration
+
+            every { typeDeclaration.isTypeParameter } returns false
+            every { typeDeclaration.wrappedNode } returns classOrInterfaceDeclaration
+
+            rewriteMockitoFieldInjections(compilationUnit)
+
+            val expectedCode = """
+                import nl.thanus.demo.controllers.UsersController;
+                
+                class UsersControllerTest {
+                    private UsersController usersController = new UsersController();
+                }
+            """.trimIndent()
+
+            assertRefactored(compilationUnit, expectedCode)
+        }
+
+        private fun configureTypeSolver(typeDeclaration: ResolvedReferenceTypeDeclaration) {
+            val memoryTypeSolver = MemoryTypeSolver()
+            memoryTypeSolver.addDeclaration("nl.thanus.demo.controllers.UsersController", typeDeclaration)
+            StaticJavaParser.getConfiguration().setSymbolResolver(JavaSymbolSolver(memoryTypeSolver))
+        }
+
+        @Test
+        fun `Object creation should not contain any constructor arguments when resolving arguments fails`() {
+            val code = """
+                import org.mockito.InjectMocks;
+                
+                class UsersControllerTest {
+                    @InjectMocks
+                    private UsersController usersController;
+                }
+            """.trimIndent()
+
+            val memoryTypeSolver = MemoryTypeSolver()
+            StaticJavaParser.getConfiguration().setSymbolResolver(JavaSymbolSolver(memoryTypeSolver))
+
+            val compilationUnit = StaticJavaParser.parse(code)
+
+            rewriteMockitoFieldInjections(compilationUnit)
+
+            val expectedCode = """
+                class UsersControllerTest {
+                    private UsersController usersController = new UsersController();
+                }
+            """.trimIndent()
+
+            assertRefactored(compilationUnit, expectedCode)
+        }
     }
 
     @Test


### PR DESCRIPTION
Constructor arguments are resolved and filled in object creation for the
Mockito field injection refactoring.

ReBoot now first refactors src directory and then the test directory.
Otherwise it has to guess how code will look like after a refactoring
(ReBooting test first, before src).

Closes #6